### PR TITLE
Highlight variables in write positions

### DIFF
--- a/syntaxes/abap.tmLanguage
+++ b/syntaxes/abap.tmLanguage
@@ -53,6 +53,12 @@
 			</dict>
 			<dict>
 				<key>match</key>
+				<string>(?i)(?&lt;=\s)([a-z_/][a-z_0-9/]*)(?=\s+=\s+)</string>
+				<key>name</key>
+				<string>variable.other.abap</string>
+			</dict>
+			<dict>
+				<key>match</key>
 				<string>\b[0-9]+(\b|\.|,)</string>
 				<key>name</key>
 				<string>constant.numeric.abap</string>
@@ -334,9 +340,20 @@
 			<key>keywords_followed_by_braces</key>
 			<dict>
 				<key>match</key>
-				<string>(?ix)\b(data|value|field-symbol)(?=\()</string>
-				<key>name</key>
-				<string>keyword.control.simple.abap</string>
+				<string>(?ix)\b(data|value|field-symbol)\((&lt;?[a-z_\/][a-z_0-9\/]*&gt;?)\)</string>
+				<key>captures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.control.simple.abap</string>
+					</dict>
+					<key>2</key>
+					<dict>
+						<key>name</key>
+						<string>variable.other.abap</string>
+					</dict>
+				</dict>
 			</dict>
 			<key>operators</key>
 			<dict>


### PR DESCRIPTION
The basic idea is that `KEYWORD = something` is not valid, therefore any single word before `=` is a variable. This doesn't cover member access chaining like `a->b-c`. To make the colors more consistent, I also included the variables in inline declarations.

The result looks quite good, it eliminates many cases where variables had keyword highlighting and distinguishes method parameters from their values.
![code_rvxccdx6xm](https://user-images.githubusercontent.com/5097067/52519730-73a22700-2c60-11e9-8b2d-b5585aacfde5.png)
