### PR TITLE
Extend ABAP language configuration

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -32,35 +32,35 @@
             ">"
         ],
         [
-            "METHOD",
+            "METHOD.",
             "ENDMETHOD."
         ],
         [
-            "method",
+            "method.",
             "endmethod."
         ],
         [
-            "IF",
+            "IF.",
             "ENDIF."
         ],
         [
-            "if",
+            "if.",
             "endif."
         ],
         [
-            "CASE",
+            "CASE.",
             "ENDCASE."
         ],
         [
-            "case",
+            "case.",
             "endcase."
         ],
         [
-            "LOOP",
+            "LOOP.",
             "ENDLOOP."
         ],
         [
-            "loop",
+            "loop.",
             "endloop."
         ],
         [
@@ -72,19 +72,19 @@
             "endtry."
         ],
         [
-            "WHILE",
+            "WHILE.",
             "ENDWHILE."
         ],
         [
-            "while",
+            "while.",
             "endwhile."
         ],
         [
-            "DO",
+            "DO.",
             "ENDDO."
         ],
         [
-            "do",
+            "do.",
             "enddo."
         ]
     ],

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -14,6 +14,78 @@
         [
             "<",
             ">"
+        ],
+        [
+            "`",
+            "`"
+        ],
+        [
+            "'",
+            "'"
+        ],
+        [
+            "|",
+            "|"
+        ],
+        [
+            "<",
+            ">"
+        ],
+        [
+            "METHOD",
+            "ENDMETHOD."
+        ],
+        [
+            "method",
+            "endmethod."
+        ],
+        [
+            "IF",
+            "ENDIF."
+        ],
+        [
+            "if",
+            "endif."
+        ],
+        [
+            "CASE",
+            "ENDCASE."
+        ],
+        [
+            "case",
+            "endcase."
+        ],
+        [
+            "LOOP",
+            "ENDLOOP."
+        ],
+        [
+            "loop",
+            "endloop."
+        ],
+        [
+            "TRY.",
+            "ENDTRY."
+        ],
+        [
+            "try.",
+            "endtry."
+        ],
+        [
+            "WHILE",
+            "ENDWHILE."
+        ],
+        [
+            "while",
+            "endwhile."
+        ],
+        [
+            "DO",
+            "ENDDO."
+        ],
+        [
+            "do",
+            "enddo."
         ]
     ],
     "surroundingPairs": [
@@ -35,13 +107,87 @@
         ]
     ],
     "indentationRules": {
-      "increaseIndentPattern": {
-        "pattern": "^\\s*(METHOD|IF|LOOP|CLASS|CASE|DO|FORM|ELSE|WHILE|TRY|CATCH).*\\.$",
-        "flags": "i"
-      },
-      "decreaseIndentPattern": {
-        "pattern": "^\\s*(ENDMETHOD|ENDIF|ENDLOOP|ENDCLASS|ENDCASE|ENDDO|ENDFORM|ELSE|ENDWHILE|ENDTRY|CATCH)\\.$",
-        "flags": "i"
-      },
-    }
+        "increaseIndentPattern": {
+            "pattern": "^\\s*(METHOD|IF|LOOP|CLASS|CASE|DO|FORM|ELSE|WHILE|TRY|CATCH).*\\.$",
+            "flags": "i"
+        },
+        "decreaseIndentPattern": {
+            "pattern": "^\\s*(ENDMETHOD|ENDIF|ENDLOOP|ENDCLASS|ENDCASE|ENDDO|ENDFORM|ELSE|ENDWHILE|ENDTRY|CATCH)\\.$",
+            "flags": "i"
+        },
+    },
+    "colorizedBracketPairs": [
+        [
+            "(",
+            ")"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "METHOD",
+            "ENDMETHOD"
+        ],
+        [
+            "method",
+            "endmethod"
+        ],
+        [
+            "IF",
+            "ENDIF"
+        ],
+        [
+            "if",
+            "endif"
+        ],
+        [
+            "CASE",
+            "ENDCASE"
+        ],
+        [
+            "case",
+            "endcase"
+        ],
+        [
+            "LOOP",
+            "ENDLOOP"
+        ],
+        [
+            "loop",
+            "endloop"
+        ],
+        [
+            "TRY",
+            "ENDTRY"
+        ],
+        [
+            "try",
+            "endtry"
+        ],
+        [
+            "WHILE",
+            "ENDWHILE"
+        ],
+        [
+            "while",
+            "endwhile"
+        ],
+        [
+            "DO",
+            "ENDDO"
+        ],
+        [
+            "do",
+            "enddo"
+        ],
+        [
+            "BEGIN",
+            "END"
+        ],
+        [
+            "begin",
+            "end"
+        ]
+    ]
 }


### PR DESCRIPTION
# Bracket pair colorization
![image](https://user-images.githubusercontent.com/5097067/140494856-0896fb35-11e9-403a-8ff8-cd3b76d9a59d.png)
![image](https://user-images.githubusercontent.com/5097067/140494901-28c9295e-88ca-4251-a081-57621481c70c.png)

Anything which has `begin` and `end` (`of` is not possible, the pairs can't contain spaces)
![image](https://user-images.githubusercontent.com/5097067/140495293-003c554b-3052-418e-99e8-ec40a0c952fb.png)

# New autoclosing pairs

Common block structures are now autoclosing pairs. So typing `if.` outside a string literal will automatically type `if.{cursor}endif.` which closes the block and leaves the cursor (almost, ideally it would be in front of the dot) in the place where you need to write the condition.

This doesn't happen if you use the keywords inside string literals which are autoclosing, so it shouldn't be too intrusive.

# Limitations

- Can't do public/protected/private section
- `if/elseif` is not possible, only the whole `if` is a pair
if you specify the pair "WHEN", "WHEN", you will get alternating colors, but I chose to leave this one out
![image](https://user-images.githubusercontent.com/5097067/140495747-95d82d42-873d-4261-9d20-bc0a1af2ed46.png)


-class-endclass is problematic because of class-methods

